### PR TITLE
initialize score object with players in logic.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ function App() {
     import('./logic').then(() =>
       Rune.initClient({
         onChange: ({ newGame, players, yourPlayerId, action, event }) => {
-          console.log(newGame)
+          console.log(Rune.actions)
         },
       })
     )

--- a/src/App.js
+++ b/src/App.js
@@ -1,33 +1,22 @@
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import WordCard from './components/WordCard';
-import { switchDay, incrementPlayer } from './features/gameStateSlice';
-const { Rune } = window;
+import React, { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import WordCard from './components/WordCard'
+import { switchDay, incrementPlayer } from './features/gameStateSlice'
+const { Rune } = window
 
 function App() {
-  const playersArr = useSelector((state) => state.gameState.currentPlayers);
-  const dispatch = useDispatch();
+  const playersArr = useSelector((state) => state.gameState.currentPlayers)
+  const dispatch = useDispatch()
   // console.log(window);
   useEffect(() => {
     import('./logic').then(() =>
       Rune.initClient({
         onChange: ({ newGame, players, yourPlayerId, action, event }) => {
-          console.log({ newGame });
-          // setGame({ game: newGame, players, yourPlayerId });
-          console.log({ Rune });
-          // setMyPlayerId(yourPlayerId);
-          // newGame.newPlayer(yourPlayerId);
-          console.log(`action`, action);
-          console.log(`event`, event);
-          console.log(newGame.playerScore);
+          console.log(newGame)
         },
       })
-    );
-  }, []);
-
-  const useGameMode = () => {
-    dispatch(switchDay());
-  };
+    )
+  }, [])
 
   function HandleInitializePlayers() {
     // dispatch(clearPlayers());
@@ -37,13 +26,13 @@ function App() {
     // const scientist = 4;
     // const busyBody = 0;
     for (let i = 0; i < 7; i++) {
-      let role = 'normal';
+      let role = 'normal'
       if (i === 3) {
-        role = 'doctor';
+        role = 'doctor'
       } else if (i === 4) {
-        role = 'scientist';
+        role = 'scientist'
       } else if (i === 0) {
-        role = 'busyBody';
+        role = 'busyBody'
       }
 
       dispatch(
@@ -52,7 +41,7 @@ function App() {
           active: true,
           role: role,
         })
-      );
+      )
     }
   }
 
@@ -74,7 +63,7 @@ function App() {
         </div>
       </header>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/logic.js
+++ b/src/logic.js
@@ -1,11 +1,15 @@
-const { Rune } = window;
+const { Rune } = window
 
 Rune.initLogic({
   minPlayers: 4,
   maxPlayers: 4,
-  setup: () => {
+  setup: (allPlayerIds) => {
+    const scores = {}
+    for (let playerId of allPlayerIds) {
+      scores[playerId] = 0
+    }
     return {
-      playerScore: {},
+      scores,
       startGame: true,
       gameOver: false,
       judge: undefined,
@@ -13,20 +17,17 @@ Rune.initLogic({
       definitions: [],
       word: '',
       winner: '',
-    };
+    }
   },
   actions: {
     startGame: (_, { game }) => {
       if (!game.judge) {
-        game.judge = Math.floor(Math.random() * 3);
+        game.judge = Math.floor(Math.random() * 3)
       } else if (game.judge === 3) {
-        game.judge = 0;
+        game.judge = 0
       } else {
-        game.judge++;
+        game.judge++
       }
-    },
-    newPlayer: (playerId, { game }) => {
-      game.playerScore[playerId] = 0;
     },
     // incrementScore: () => {
     //   //adds scores to the winner
@@ -49,8 +50,11 @@ Rune.initLogic({
     // },
   },
   events: {
+    /**
+     * This callback runs when additional players join after the server is running.
+     */
     playerJoined: (playerId, { game }) => {
-      game.playerScore[playerId] = 0;
+      game.playerScore[playerId] = 0
     },
   },
-});
+})


### PR DESCRIPTION
We figured out that the player joined event only occurs after new (addtional) players join the game/server once the server is already running. I've added coded to initialize the scores of the existing current players to 0 in the `setup` function. I was able to figure out by looking at the code example [here](https://developers.rune.ai/docs/api-reference#runeinitlogicoptions).